### PR TITLE
Minor fix to bulk indexer

### DIFF
--- a/lib/elastix/document.ex
+++ b/lib/elastix/document.ex
@@ -13,7 +13,8 @@ defmodule Elastix.Document do
       |> Enum.map(fn d -> bulk_document(index_name, type_name, d) end)
       |> Enum.join("\n")
 
-    elastic_url <> make_path(index_name, type_name, "_bulk", []) 
+    json = json <> "\n"
+    elastic_url <> make_path(index_name, type_name, "_bulk", [])
     |> HTTP.put(json)
     |> process_response
   end


### PR DESCRIPTION
@nauger Two things:

1) We are way behind on the main fork of this repo. They've overhauled bulk indexing to work slightly differently. We may want to upgrade at some point
2) For some reason, the bulk indexing API needs to have a trailing "\n" after the payload. Best explanation I can find is here: https://github.com/elastic/elasticsearch/issues/11435#issuecomment-108134394 . This issue causes elastic to "skip" docs (i think it skips the last one in each batch).

I reran my blog article index and the article ID i consistently noticed as missing is now there, as it should be.