### PR TITLE
Add missing parens to eliminate compilation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,11 +9,11 @@ defmodule Elastix.Mixfile do
       version: @version,
       elixir: "~> 1.0",
       description: "A simple Elastic REST client written in Elixir.",
-      package: package,
+      package: package(),
       docs: [source_ref: "v#{@version}", main: "overview"],
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
Add missing parens to eliminate compilation warnings